### PR TITLE
update driver and LM4 for use of fms 2025.03 and spack-stack 2.1.x

### DIFF
--- a/nuopc_cap/lm4_cap.F90
+++ b/nuopc_cap/lm4_cap.F90
@@ -23,7 +23,6 @@ module lm4_cap_mod
    use lm4_import_export,    only: advertise_fields, realize_fields, &
                                    import_fields, correct_import_fields, export_fields
    use fms_mod,              only: fms_init, fms_end, uppercase
-   use fms_io_mod,           only: fms_io_exit
 
    use mpp_mod,              only: mpp_error,FATAL, WARNING
    use diag_manager_mod,     only: diag_manager_init, diag_manager_end, &
@@ -351,7 +350,7 @@ contains
    !===============================================================================
    subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
 
-      use fms_io_mod,         only: field_exist, read_data
+      use fms2_io_mod,        only: read_data, open_file, close_file, FmsNetcdfFile_t, variable_exists
 
       ! input/output variables
       type(ESMF_GridComp)  :: gcomp
@@ -373,18 +372,21 @@ contains
       character(len=CL)           :: logmsg
       logical                     :: isPresent, isSet
 
+      type(FmsNetcdfFile_t)       :: fileobj
+
       !-------------------------------------------------------------------------------
 
       rc = ESMF_SUCCESS
       call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO)
 
-      !geomtype = ESMF_GEOMTYPE_GRID
-
       gridfile = "grid_spec.nc" ! default
-      if (field_exist("INPUT/grid_spec.nc", "atm_mosaic_file")) then
-         call read_data("INPUT/grid_spec.nc", "atm_mosaic_file", gridfile)
-      endif
 
+      if (open_file(fileobj, "INPUT/grid_spec.nc", "read")) then
+         if (variable_exists(fileobj, "atm_mosaic_file")) then
+            call read_data(fileobj, "atm_mosaic_file", gridfile)
+         endif
+         call close_file(fileobj)
+      endif
 
 
       do tl=1,6
@@ -611,8 +613,7 @@ contains
       call land_model_end(lm4_model%From_atm, lm4_model%From_lnd)
 
       call diag_manager_end(lm4_model%Time_end)
-      call fms_io_exit  ! TEST
-      call fms_end      ! TEST
+      call fms_end    
 
       ! deallocate storage for the atm forc data
       call dealloc_atmforc(lm4_model%atm_forc)

--- a/nuopc_cap/lm4_driver.F90
+++ b/nuopc_cap/lm4_driver.F90
@@ -128,13 +128,10 @@ contains
    !! ============================================================================
    subroutine lm4_nml_read(lm4_model)
 
-      use fms_mod,             only: check_nml_error, file_exist
+      use fms_mod,             only: check_nml_error
       use fms2_io_mod,         only: close_file
-#ifdef INTERNAL_FILE_NML
       use mpp_mod,             only: input_nml_file
-#else
-      use fms_mod,             only: open_namelist_file
-#endif
+
 
       type(lm4_type),          intent(inout) :: lm4_model ! land model's variable type
 
@@ -160,39 +157,16 @@ contains
 
       ! read in namelists
       ! ------------------------------------------
-      if ( file_exist('input.nml')) then
-#ifdef INTERNAL_FILE_NML
-         ! lm4_nml
-         read(input_nml_file, nml=lm4_nml, iostat=io)
-         ierr = check_nml_error(io, 'lm4_nml')
+      ! lm4_nml
+      read(input_nml_file, nml=lm4_nml, iostat=io)
+      ierr = check_nml_error(io, 'lm4_nml')
 
-         read(input_nml_file, nml=atmos_prescr_nml, iostat=io)
-         ierr = check_nml_error(io, 'atmos_prescr_nml')
+      read(input_nml_file, nml=atmos_prescr_nml, iostat=io)
+      ierr = check_nml_error(io, 'atmos_prescr_nml')
 
-         read(input_nml_file, nml=flux_exchange_nml, iostat=io)
-         ierr = check_nml_error(io, 'flux_exchange_nml')
-#else
-         unit = open_namelist_file ( )
-         ierr=1
-         do while (ierr /= 0)
-            read(unit, nml=lm4_nml, iostat=io)
-            ierr = check_nml_error(io,'lm4_nml')
-         enddo
+      read(input_nml_file, nml=flux_exchange_nml, iostat=io)
+      ierr = check_nml_error(io, 'flux_exchange_nml')
 
-         ierr=1
-         do while (ierr /= 0)
-            read(unit, nml=atmos_prescr_nml, iostat=io)
-            ierr = check_nml_error(io,'atmos_prescr_nml')
-         enddo        
-         
-         ierr=1
-         do while (ierr /= 0)
-            read(unit, nml=flux_exchange_nml, iostat=io)
-            ierr = check_nml_error(io,'flux_exchange_nml')
-         enddo             
-         call close_file(unit)
-#endif
-      endif
 
       lm4_model%nml%lm4_debug   = lm4_debug
       lm4_model%nml%grid        = grid

--- a/nuopc_cap/lm4_driver.F90
+++ b/nuopc_cap/lm4_driver.F90
@@ -128,7 +128,8 @@ contains
    !! ============================================================================
    subroutine lm4_nml_read(lm4_model)
 
-      use fms_mod,             only: check_nml_error, close_file, file_exist
+      use fms_mod,             only: check_nml_error, file_exist
+      use fms2_io_mod,         only: close_file
 #ifdef INTERNAL_FILE_NML
       use mpp_mod,             only: input_nml_file
 #else

--- a/nuopc_cap/lm4_surface_flux.F90
+++ b/nuopc_cap/lm4_surface_flux.F90
@@ -2,8 +2,8 @@
 !! ============================================================================
 module lm4_surface_flux_mod
 
-   use             fms_mod, only: close_file, mpp_pe, mpp_root_pe, write_version_number
-   use             fms_mod, only: file_exist, check_nml_error, open_namelist_file, stdlog
+   use             fms_mod, only: mpp_pe, mpp_root_pe
+   use             fms_mod, only: check_nml_error, stdlog
    use   monin_obukhov_mod, only: mo_drag, mo_profile, monin_obukhov_init
    use  sat_vapor_pres_mod, only: escomp, descomp
    use       constants_mod, only: cp_air, hlv, stefan, rdgas, rvgas, grav, vonkarm
@@ -78,20 +78,10 @@ contains
       integer :: unit, ierr, io
 
       ! read namelist
-#ifdef INTERNAL_FILE_NML
       read (input_nml_file, surface_flux_nml, iostat=io)
       ierr = check_nml_error(io,'surface_flux_nml')
-#else
-      if ( file_exist('input.nml')) then
-         unit = open_namelist_file ()
-         ierr=1;
-         do while (ierr /= 0)
-            read  (unit, nml=surface_flux_nml, iostat=io)
-            ierr = check_nml_error(io,'surface_flux_nml')
-         enddo
-           call close_file (unit)
-      endif
-#endif
+
+
 
       unit = stdlog()
       if ( mpp_pe() == mpp_root_pe() )  write (unit, nml=surface_flux_nml)


### PR DESCRIPTION
Update LM4-NUOPC and LM4 subrepo to be compatible with FMS 2025.03

needed for https://github.com/ufs-community/ufs-weather-model/pull/3174,  UFS issue: https://github.com/ufs-community/ufs-weather-model/issues/3212


existing LM4 commit [land_lad2_2023.02](https://github.com/NOAA-GFDL/lm4/commit/c61e4e280dbde13af0023b1e86d98296ff65d6a7) looks sufficient for FMS 2025.03

This passes datm_cdeps_lm4_gswp3_intel and Running test datm_cdeps_lm4_gswp3_rst_intel using current UFS develop, but RTs show changes w.r.t baseline with https://github.com/ufs-community/ufs-weather-model/pull/3174. 